### PR TITLE
feat: gain functions

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,11 @@
       pythonPkgs = pkgs.python310Packages;
     in {
       devShells.${system}.default = pkgs.mkShell {
-        buildInputs = with pythonPkgs; [numpy pandas];
+        buildInputs = with pythonPkgs; [
+          numpy
+          pandas
+          multimethod
+        ];
       };
 
       packages.${system}.default = with pythonPkgs; {

--- a/qify/measure/__init__.py
+++ b/qify/measure/__init__.py
@@ -1,1 +1,2 @@
 from . import bayes
+from . import g

--- a/qify/measure/g.py
+++ b/qify/measure/g.py
@@ -1,0 +1,116 @@
+from collections.abc import Callable, Iterable
+from multimethod import multimethod
+from typing import Any
+
+import pandas as pd
+
+from qify.channel.core import Channel
+from qify.probab_dist.core import ProbabDist
+
+@multimethod
+def prior(pi: ProbabDist, g_series: pd.Series) -> float:
+    """
+    Computes the prior g-vulnerability of a distribution.
+
+    :param g_series: pandas Series indexed by actions and secrets.
+    
+    ## Example
+
+    Consider a 2-bit password and say that the user is allowed two
+    attempts before getting locked. The set of possible actions is
+    W = {(00, -), (01, -), ..., (00, 01), ..., (11, 10)}, where a
+    dash in the second attempt indicates that the user got it
+    right in the first try, and noting that repeating a wrong
+    password makes no sense.
+
+    >>> from qify.probab_dist import uniform
+    >>> secrets = ["00", "01", "10", "11"]
+    >>> actions = (
+    ...   [(x, "-") for x in secrets] +
+    ...   [(x, y) for x in secrets for y in secrets if x != y]
+    ... )
+    >>> index = pd.MultiIndex.from_tuples(
+    ...   [(w, x) for w in actions for x in secrets],
+    ...   names=["action", "secret"]
+    ... )
+    >>> g_series = pd.Series(
+    ...   {(w, x): 1 if x in w else 0 for w, x in index},
+    ...   index=index
+    ... )
+    >>> pi = uniform(secrets,  "password")
+    >>> prior(pi, g_series)
+    0.5
+
+    The cells in which gain is 0 are not really necessary, though:
+    
+    >>> index = pd.MultiIndex.from_tuples(
+    ...   [(w, x) for w in actions for x in secrets if x in w],
+    ...   names=["action", "secret"]
+    ... )
+    >>> g_series = pd.Series([1] * len(index), index=index)
+    >>> pi = uniform(secrets,  "password")
+    >>> prior(pi, g_series)
+    0.5
+    """
+    return (
+        pi
+        .mul(g_series, level="secret")
+        .groupby("action")
+        .sum()
+        .max()
+    )
+
+@multimethod
+def prior(
+    pi: ProbabDist,
+    g_func: Callable,
+    actions: Iterable
+) -> float:
+    """
+    Computes the prior g-vulnerability of a distribution.
+
+    ## Example
+
+    Instead of a pandas Series, you can provide a gain function:
+
+    >>> from qify.probab_dist import uniform
+    >>> secrets = ["00", "01", "10", "11"]
+    >>> actions = (
+    ...   [(x, "-") for x in secrets] +
+    ...   [(x, y) for x in secrets for y in secrets if x != y]
+    ... )
+    >>> pi = uniform(secrets,  "password")
+    >>> prior(pi, lambda w, x: 1 if x in w else 0, actions)
+    0.5
+    """
+    index = pd.MultiIndex.from_tuples(
+        [(w, x) for w in actions for x in pi.input_values],
+        names=["action", "secret"]
+    )
+
+    g_series = pd.Series(
+        {(w, x): g_func(w, x) for w, x in index},
+        index=index
+    )
+
+    return prior(pi, g_series)
+
+@multimethod
+def prior(pi: ProbabDist, g_func: Callable) -> float:
+    """
+    Computes the prior g-vulnerability of a distribution.
+    Assumes that the set of actions is the same of the secrets.
+
+    ## Example
+
+    Consider a 2-bit password and say that the user is allowed only
+    one attempt before getting locked. Then, the user's possible
+    actions are to guess one of the four possible passwords, and
+    thus the set of actions is exactly the set of secrets:
+
+    >>> from qify.probab_dist import uniform
+    >>> secrets = ["00", "01", "10", "11"]
+    >>> prior(pi, lambda w, x: 1 if x in w else 0)
+    0.25
+    """
+    return prior(pi, g_func, pi.input_values)

--- a/qify/measure/g.py
+++ b/qify/measure/g.py
@@ -7,6 +7,27 @@ import pandas as pd
 from qify.channel.core import Channel
 from qify.probab_dist.core import ProbabDist
 
+def _from_func(
+    g_func: Callable,
+    secret_name: str,
+    secrets: Iterable,
+    actions: Iterable
+) -> pd.Series:
+    """
+    Takes a callable and converts into a pandas Series representing
+    a gain function, indexed by secrets and actions.
+    """
+    index = pd.MultiIndex.from_tuples(
+        [(w, x) for w in actions for x in secrets],
+        names=["action", secret_name]
+    )
+
+    return pd.Series(
+        {(w, x): g_func(w, x) for w, x in index},
+        index=index
+    )
+
+
 @multimethod
 def prior(pi: ProbabDist, g_series: pd.Series) -> float:
     """
@@ -55,13 +76,7 @@ def prior(pi: ProbabDist, g_series: pd.Series) -> float:
     >>> prior(pi, g_series)
     0.5
     """
-    return (
-        pi
-        .mul(g_series, level=pi.name)
-        .groupby("action")
-        .sum()
-        .max()
-    )
+    return pi.mul(g_series).groupby("action").sum().max()
 
 
 @multimethod
@@ -87,14 +102,203 @@ def prior(
     >>> prior(pi, lambda w, x: 1 if x in w else 0, actions)
     0.5
     """
-    index = pd.MultiIndex.from_tuples(
-        [(w, x) for w in actions for x in pi.input_values],
-        names=["action", pi.name]
-    )
+    return prior(pi, _from_func(
+        g_func, pi.name, pi.input_values, actions
+    ))
 
-    g_series = pd.Series(
-        {(w, x): g_func(w, x) for w, x in index},
-        index=index
-    )
 
-    return prior(pi, g_series)
+@multimethod
+def prior(pi: ProbabDist, g_func: Callable) -> float:
+    """
+    Computes the prior g-vulnerability of a distribution.
+    Assumes that the set of actions is the same of the secrets.
+
+    ## Example
+
+    Consider a 2-bit password and say that the user is allowed only
+    one attempt before getting locked. Then, the user's possible
+    actions are to guess one of the four possible passwords, and
+    thus the set of actions is exactly the set of secrets:
+
+    >>> from qify.probab_dist import uniform
+    >>> secrets = ["00", "01", "10", "11"]
+    >>> prior(pi, lambda w, x: 1 if x in w else 0)
+    0.25
+    """
+    return prior(pi, g_func, pi.input_values)
+
+
+@multimethod
+def posterior(
+    pi: ProbabDist,
+    ch: Channel,
+    g_series: pd.Series,
+    max_case: bool = False
+) -> float:
+    """
+    Computes the posterior g-vulnerability of a channel `ch`,
+    given a prior distribution `pi`.
+
+    :param g_series: pandas Series indexed by actions and secrets.
+    	The index level that refers to the secret values must match
+    	the name of the index in the prior `pi`, while the index
+    	level that refers to the actions must be named "action".
+    
+    ## Example
+    
+    Say we are modelling a 2-bit password checker and consider a
+    particular password 10. What is the chance of someone guessing
+    this password correctly, given that they have observed the
+    behavior of the system: reject immediately the first wrong bit,
+    and they are allowed two attempts before getting locked out?
+
+    >>> import pandas as pd
+    >>> import qify
+    >>> secrets = ["00", "01", "10", "11"]
+    >>> ch_index = pd.MultiIndex.from_tuples(
+    ...   [("00", "Reject 1st"), ("01", "Reject 1st"),
+    ...    ("10", "Accept"), ("11", "Reject 2nd")],
+    ...   names=["password", "obs"]
+    ... )
+    >>> ch = qify.Channel(
+    ...   pd.Series([1, 1, 1, 1], index=ch_index),
+    ...   "password", ["obs"]
+    ... )
+    >>> pi = qify.ProbabDist(
+    ...   [1/6, 1/3, 1/3, 1/6], secrets, "password"
+    ... )
+    >>> actions = (
+    ...   [(x, "-") for x in secrets] +
+    ...   [(x, y) for x in secrets for y in secrets if x != y]
+    ... )
+    >>> g_index = pd.MultiIndex.from_tuples(
+    ...   [(w, x) for w in actions for x in secrets],
+    ...   names=["action", "password"]
+    ... )
+    >>> g_series = pd.Series(
+    ...   {(w, x): 1 if x in w else 0 for w, x in g_index},
+    ...   index=g_index
+    ... )
+
+    We may be interested in the expected case:
+
+    >>> posterior(pi, ch, g_series)
+    0.8333333333333333
+
+    Or in the worst scenario possible:
+    
+    >>> posterior(pi, ch, g_series, max_case=True)
+    1.0
+    """
+    joint = ch.push_prior(pi)
+    outer_dist = joint.groupby(ch.output_names).sum()
+    hyper = joint.div(outer_dist)
+    vulns = hyper.mul(g_series).groupby(ch.output_names).max()
+    return vulns.max() if max_case else vulns.mul(outer_dist).sum()
+
+
+@multimethod
+def posterior(
+    pi: ProbabDist,
+    ch: Channel,
+    g_func: Callable,
+    actions: Iterable,
+    max_case: bool = False
+) -> float:
+    """
+    Computes the posterior g-vulnerability of a channel `ch`,
+    given a prior distribution `pi`.
+
+    ## Example
+
+    Instead of a pandas Series, you can provide a gain function:
+
+    >>> import pandas as pd
+    >>> import qify
+    >>> secrets = ["00", "01", "10", "11"]
+    >>> ch_index = pd.MultiIndex.from_tuples(
+    ...   [("00", "Reject 1st"), ("01", "Reject 1st"),
+    ...    ("10", "Accept"), ("11", "Reject 2nd")],
+    ...   names=["password", "obs"]
+    ... )
+    >>> ch = qify.Channel(
+    ...   pd.Series([1, 1, 1, 1], index=ch_index),
+    ...   "password", ["obs"]
+    ... )
+    >>> pi = qify.ProbabDist(
+    ...   [1/6, 1/3, 1/3, 1/6], secrets, "password"
+    ... )
+    >>> actions = (
+    ...   [(x, "-") for x in secrets] +
+    ...   [(x, y) for x in secrets for y in secrets if x != y]
+    ... )
+    >>> posterior(pi, ch, lambda w, x: 1 if x in w else 0, actions)
+    0.8333333333333333
+
+    Or in the worst scenario possible:
+    
+    >>> posterior(
+    ...   pi, ch,
+    ...   lambda w, x: 1 if x in w else 0,
+    ...   actions, max_case=True
+    ... )
+    1.0
+    """
+    return posterior(pi, ch, _from_func(
+        g_func, pi.name, pi.input_values, actions
+    ), max_case)
+
+
+@multimethod
+def posterior(
+    pi: ProbabDist,
+    ch: Channel,
+    g_func: Callable,
+    max_case: bool = False
+) -> float:
+    """
+    Computes the posterior g-vulnerability of a channel `ch`,
+    given a prior distribution `pi`. Assumes that the set of
+    actions is the same of the secrets.
+
+    ## Example
+
+    Consider a 2-bit password and say that the user is allowed only
+    one attempt before getting locked. Then, the user's possible
+    actions are to guess one of the four possible passwords, and
+    thus the set of actions is exactly the set of secrets:
+
+    >>> import pandas as pd
+    >>> import qify
+    >>> secrets = ["00", "01", "10", "11"]
+    >>> ch_index = pd.MultiIndex.from_tuples(
+    ...   [("00", "Reject 1st"), ("01", "Reject 1st"),
+    ...    ("10", "Accept"), ("11", "Reject 2nd")],
+    ...   names=["password", "obs"]
+    ... )
+    >>> ch = qify.Channel(
+    ...   pd.Series([1, 1, 1, 1], index=ch_index),
+    ...   "password", ["obs"]
+    ... )
+    >>> pi = qify.ProbabDist(
+    ...   [1/6, 1/3, 1/3, 1/6], secrets, "password"
+    ... )
+    >>> actions = (
+    ...   [(x, "-") for x in secrets] +
+    ...   [(x, y) for x in secrets for y in secrets if x != y]
+    ... )
+    >>> posterior(pi, ch, lambda w, x: 1 if x in w else 0)
+    0.8333333333333333
+
+    Or in the worst scenario possible:
+    
+    >>> posterior(
+    ...   pi, ch,
+    ...   lambda w, x: 1 if x in w else 0,
+    ...   max_case=True
+    ... )
+    1.0
+    """
+    return posterior(pi, ch, _from_func(
+        g_func, pi.name, pi.input_values, pi.input_values,
+    ), max_case)

--- a/qify/probab_dist/core.py
+++ b/qify/probab_dist/core.py
@@ -65,8 +65,6 @@ class ProbabDist:
         if not is_proper(self._dist):
             raise ValueError("Invalid probability distribution!")
 
-        self._name = name
-        
         # Increment the class with some methods from pandas Series,
         # so that it works kinda like a wrapper for Series:
         methods = ["min", "max", "sum", "mul"]
@@ -75,8 +73,13 @@ class ProbabDist:
         
 
     @property
+    def input_values(self) -> pd.Index:
+        return self._dist.index
+
+    
+    @property
     def name(self) -> str:
-        return self._name
+        return self.input_values.name
 
 
     def __repr__(self) -> str:

--- a/tests/measure/test_g.py
+++ b/tests/measure/test_g.py
@@ -1,0 +1,8 @@
+import doctest
+import unittest
+
+from qify.measure import g
+
+def load_tests(loader, tests, ignore):
+    tests.addTests(doctest.DocTestSuite(g))
+    return tests


### PR DESCRIPTION
Adds g-vulnerability measure, along with multiplicative and additive g-leakage. Each function accepts either a pandas Series representing the gain function, indexed by actions and secrets, or a callable that takes an action $w$ and a secret $g$ plus the set of actions (if omitted, the set of actions is assumed to be equal to the set of secrets).

For example, prior Bayes vulnerability could be implemented with gain functions as follows:

a) Using a pandas Series (no need for the entries $w$ and $x$ for which $g(w, x) = 0$):

```python
>>> import qify
>>> import pandas as pd
>>> secret_label = "secret"
>>> secrets = ["x0", "x1", "x2", "x3"]
>>> actions = ["x0", "x1", "x2", "x3"]
>>> g_index = pd.MultiIndex.from_tuples(zip(actions, secrets), names=["action", secret_label])
>>> g_series = pd.Series([1] * len(g_index), index=g_index)
>>> pi = qify.probab_dist.uniform(secrets, secret_label)
>>> qify.measure.g.prior(pi, g_series)
0.25
```

b) Using a callable, specifying the set of actions:

```python
>>> import qify
>>> import pandas as pd
>>> secret_label = "secret"
>>> secrets = ["x0", "x1", "x2", "x3"]
>>> actions = ["x0", "x1", "x2", "x3"]
>>> pi = qify.probab_dist.uniform(secrets, secret_label)
>>> qify.measure.g.prior(pi, lambda w, x: 1 if w == x else 0, actions)
0.25
```

c) Using a callable, but omitting the set of actions:

```python
>>> import qify
>>> import pandas as pd
>>> secret_label = "secret"
>>> secrets = ["x0", "x1", "x2", "x3"]
>>> pi = qify.probab_dist.uniform(secrets, secret_label)
>>> qify.measure.g.prior(pi, lambda w, x: 1 if w == x else 0)
0.25
```
